### PR TITLE
Remove image checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.idea

--- a/src/apps/SpreadsheetApp/SpreadsheetAppp.js
+++ b/src/apps/SpreadsheetApp/SpreadsheetAppp.js
@@ -55,17 +55,16 @@
       insertImage(objAr_) {
         var ar, blob, dstSS, dstSheet, dstSheetId, e, requests, tmpId, tmpSheet, tmpSheetId, xlsxObj;
         if (!Array.isArray(objAr_) || (objAr_.some(({blob, range}) => {
-          var height, identification, width;
+          var identification;
           if (blob.toString() !== "Blob" || !range.row || !range.column || isNaN(range.row) || isNaN(range.column)) {
+            console.log('[DocsServiceApp]', 'Issue with Blob or range coordinates')
             return true;
           }
-          ({width, height, identification} = ImgAppp.getSize(blob));
-          if (width * height > 1048576) {
-            return true;
-          }
+          ({identification} = ImgAppp.getSize(blob));
           if (!(["GIF", "PNG", "JPG"].some((e) => {
             return e === identification;
           }))) {
+            console.log('[DocsServiceApp]', 'Issue with file format', 'received', identification)
             return true;
           }
           return false;
@@ -84,7 +83,6 @@
             title: "SpreadsheetAppp_temp",
             mimeType: MimeType.GOOGLE_SHEETS
           }, blob).id;
-		  console.log(`LIB`, "TMP ID AFYTER INSER", tmpId);
         } catch (error) {
           e = error;
 		  console.log(`ERROR`, error);


### PR DESCRIPTION
It appears that when the images are too big the lib fails with the message
`Wrong object. Please confirm it again. By the way, the maximum image size is 'width x height < 1048576'. And the mimeTypes are PNG, JPG and GIF.`
This is due to the image size. I tested it with 4k image inserted in cell and it worked for me, so I am not sure why exactly there is a check apart from reference from README.md where it's stated:

> When the images are retrieved from XLSX data, it seems that the image is a bit different from the original one. The image format is the same. But the data size is smaller than that of the original. When the image size is more than 2048 pixels and 72 dpi, the image is modified to 2048 pixels and 72 dpi. Even when the image size is less than 2048 pixels and 72 dpi, the file size becomes smaller than that of original one. So I think that the image might be compressed. Please be careful this.

I don't see a harm in using images more than the sizes in the checks apart from degraded image quality.
I suggest we come back to this if we have any complains about image quality degradation.