### PR TITLE
FPR-861 Additional logs for temp file generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scriptaddicts/docsserviceapp",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Fork of DocsServiceApp to continue support of the library",
   "main": "index.js",
   "scripts": {

--- a/src/apps/SpreadsheetApp/SpreadsheetAppp.js
+++ b/src/apps/SpreadsheetApp/SpreadsheetAppp.js
@@ -78,9 +78,14 @@
         createDrawing1Xml_.call(this, xlsxObj, ar);
         drawing1XmlRels_.call(this, xlsxObj, ar);
         blob = xlsxObjToBlob.call(this, xlsxObj);
+        dstSS = SpreadsheetApp.openById(this.obj.spreadsheetId);
+        dstSheet = dstSS.getSheetByName(this.obj.sheetName);
+        dstSheetId = dstSheet.getSheetId();
+		const tempFileName =`SpreadsheetAppp_temp_${dstSS.getId()}` 
+		console.log('[DocsServiceApp]', 'attempting to generate temp file for ->', dstSS.getId(), dstSS.getName(), dstSheetId)
         try {
           tmpId = Drive.Files.insert({
-            title: "SpreadsheetAppp_temp",
+            title: tempFileName,
             mimeType: MimeType.GOOGLE_SHEETS
           }, blob).id;
         } catch (error) {
@@ -92,9 +97,6 @@
             putError.call(this, e.message);
           }
         }
-        dstSS = SpreadsheetApp.openById(this.obj.spreadsheetId);
-        dstSheet = dstSS.getSheetByName(this.obj.sheetName);
-        dstSheetId = dstSheet.getSheetId();
         tmpSheet = SpreadsheetApp.openById(tmpId).getSheets()[0].setName(`SpreadsheetAppp_${Utilities.getUuid()}`).copyTo(dstSS);
 		Drive.Files.remove(tmpId);
         tmpSheetId = tmpSheet.getSheetId();


### PR DESCRIPTION
Currently it is hard to tie a temp file generation into a FP file generation (in case temp file is failed to be removed, we need to at least know which form produces these files)

Example ticket where we are not sure which form temp file relates to: Support Ticket Details - FP 14138