### PR TITLE
FPR-886 Clean up temp files in case of inserting sheets failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scriptaddicts/docsserviceapp",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Fork of DocsServiceApp to continue support of the library",
   "main": "index.js",
   "scripts": {

--- a/src/apps/SpreadsheetApp/SpreadsheetAppp.js
+++ b/src/apps/SpreadsheetApp/SpreadsheetAppp.js
@@ -184,6 +184,8 @@
           if (tmpId) {
             Drive.Files.remove(tmpId);
           }
+
+          throw err;
         }
         tmpSheetId = tmpSheet.getSheetId();
         requests = ar.map((e) => {

--- a/src/apps/SpreadsheetApp/SpreadsheetAppp.js
+++ b/src/apps/SpreadsheetApp/SpreadsheetAppp.js
@@ -249,22 +249,31 @@
     gToM = function () {
       var obj, url;
       url = `https://www.googleapis.com/drive/v3/files/${this.obj.spreadsheetId}/export?mimeType=${MimeType.MICROSOFT_EXCEL}`;
-			console.log(
-				"[FPR-859] Requesting MS export",
-				"Library object ->",
-				JSON.stringify(this.obj || {}),
-				"Request URL ->",
-				url
-			)
-			try {
-				console.log("[FPR-859] Request headers -> ", JSON.stringify(this.headers || {}))
-				obj = UrlFetchApp.fetch(url, {
-					headers: this.headers,
-				});
-				console.log("[FPR-859] Successfull MS file export response ->", obj.getResponseCode())
-			} catch (err) {
-				console.log("[FPR-859] Errored MS file export response -> ", obj.getResponseCode())
-			}
+      console.log(
+        "[FPR-859] Requesting MS export",
+        "Library object ->",
+        JSON.stringify(this.obj || {}),
+        "Request URL ->",
+        url
+      );
+      try {
+        console.log(
+          "[FPR-859] Request headers -> ",
+          JSON.stringify(this.headers || {})
+        );
+        obj = UrlFetchApp.fetch(url, {
+          headers: this.headers,
+        });
+        console.log(
+          "[FPR-859] Successfull MS file export response ->",
+          obj.getResponseCode()
+        );
+      } catch (err) {
+        console.log(
+          "[FPR-859] Errored MS file export response -> ",
+          obj.getResponseCode()
+        );
+      }
       if (obj.getResponseCode() !== 200) {
         putError.call(
           this,

--- a/src/apps/SpreadsheetApp/SpreadsheetAppp.js
+++ b/src/apps/SpreadsheetApp/SpreadsheetAppp.js
@@ -165,11 +165,26 @@
             putError.call(this, e.message);
           }
         }
-        tmpSheet = SpreadsheetApp.openById(tmpId)
-          .getSheets()[0]
-          .setName(`SpreadsheetAppp_${Utilities.getUuid()}`)
-          .copyTo(dstSS);
-        Drive.Files.remove(tmpId);
+        try {
+          const tmpSpreadsheet = SpreadsheetAppp.openById(tmpId);
+          tmpSheet = tmpSpreadsheet.getSheets()[0];
+          tmpSheet.setName(`SpreadsheetAppp_${Utilities.getUuid()}`);
+          tmpSheet.copyTo(dstSS);
+
+          Drive.Files.remove(tmpId);
+        } catch (err) {
+          // in case of failure remove Temp generated file to avoid spamming
+          console.log(
+            "[DocsServiceApp]",
+            "Error copying tmp file into destination",
+            err.name,
+            err.message
+          );
+
+          if (tmpId) {
+            Drive.Files.remove(tmpId);
+          }
+        }
         tmpSheetId = tmpSheet.getSheetId();
         requests = ar.map((e) => {
           e.from.sheetId = tmpSheetId;


### PR DESCRIPTION
Wrapped the copying sheets data from source sheet to destination sheet in `try..catch` and remove temp file if there was a failure for whatever reason